### PR TITLE
🐛 fix hard filter

### DIFF
--- a/tools/bcftools_filter_vcf.cwl
+++ b/tools/bcftools_filter_vcf.cwl
@@ -59,5 +59,5 @@ outputs:
   filtered_vcf:
     type: File
     outputBinding:
-      glob: '*bcf_filtered*'
+      glob: "*.{v,b}cf{,.gz}"
     secondaryFiles: ['.tbi?']

--- a/tools/bcftools_filter_vcf.cwl
+++ b/tools/bcftools_filter_vcf.cwl
@@ -5,46 +5,59 @@ doc: "More generic tool to take in an include expression and optionally an exclu
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bvcftools:latest'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bcftools:1.20'
   - class: ResourceRequirement
-    ramMin: 1000
-    coresMin: 1
+    ramMin: 16000
+    coresMin: 8
   - class: InlineJavascriptRequirement
-baseCommand: [bash -c 'set -eo pipefail &&]
+baseCommand: []
 arguments:
-  - position: 1
+  - position: 0
     shellQuote: false
     valueFrom: >-
       ${
-        var out_base = inputs.output_basename;
-        if (out_base == null){
-          out_base = inputs.input_vcf.nameroot + ".bcf_filtered"
+        var cmd  = "bcftools view"
+        if ( inputs.sample_name != null ){
+          cmd += " --threads " + inputs.threads + " -s " + inputs.sample_name + " " + inputs.input_vcf.path + " | bcftools view ";
         }
-        var cmd = "bcftools view ";
-        if (inputs.include_expression != null){
-            cmd += "--include \"" + inputs.include_expression + "\" " + inputs.input_vcf.path;
-            if (inputs.exclude_expression != null){
-                cmd += " | bcftools view --exclude \"" + inputs.exclude_expression + "\"' -O z > " + out_base + ".vcf.gz;";
-            } else {
-                cmd += " -O z > " + out_base + ".vcf.gz;";
-            }
-        } else if (inputs.include_expression == null && inputs.exclude_expression != null){
-            cmd += "--exclude \"" + inputs.exclude_expression + "\" " + inputs.input_vcf.path + " -O z > " + out_base + ".vcf.gz;";
-        } else if (inputs.include_expression == null && inputs.exclude_expression == null){
-            cmd = "cp " + inputs.input_vcf.path + " ./" + out_base + ".vcf.gz;";
-        }
-        cmd += "tabix " + out_base + ".vcf.gz;'"
         return cmd;
+      }
+  - position: 2
+    shellQuote: false
+    valueFrom: >-
+      ${
+        var arg = " -o " + inputs.output_basename + ".bcf_filtered"
+        if (inputs.output_type == "v"){
+          arg += ".vcf"
+        } else if (inputs.output_type == "z"){
+          arg += ".vcf.gz && tabix " + inputs.output_basename + ".bcf_filtered.vcf.gz"
+        } else if (inputs.output_type == "b"){
+          arg += ".bcf.gz"
+        } else{
+          arg += ".bcf"
+        }
+        if (inputs.sample_name == null){
+          arg = inputs.input_vcf.path + arg;
+        }
+        return arg;
       }
 
 inputs:
   input_vcf: File
-  include_expression: ['null', string]
-  exclude_expression: ['null', string]
-  output_basename: ['null', string]
+  include_expression: { type: 'string?', doc: "See bcftools docs for valid expression. Can't be used at the same time as exclude_expression. Use double quotes when a string needs to be quoted",
+    inputBinding: { position: 1, prefix: "--include", shellQuote: true} }
+  threads: { type: 'int?', default: 4, inputBinding: {position: 1, prefix: "--threads"} }
+  exclude_expression: { type: 'string?', doc: "See bcftools docs for valid expression. Can't be used at the same time as include_expression.  Use double quotes when a string needs to be quoted",
+    inputBinding: { position: 1, prefix: "--exclude", shellQuote: true} }
+  filter_expression: { type: 'string?', doc: "Add values from FILTER field to subset on",
+    inputBinding: { position: 1, prefix: "-f"}}
+  output_type: { type: [ 'null', {type: enum, name: output_type, symbols: [ "u", "b", "v", "z"]}],
+    inputBinding: { position: 1, prefix: "-O"}, default: "z" }
+  sample_name: { type: 'string?', doc: "csv string of samples if user wishes to apply filtering to and output specific samples"}
+  output_basename: string
 outputs:
   filtered_vcf:
     type: File
     outputBinding:
-      glob: '*.vcf.gz'
-    secondaryFiles: [.tbi]
+      glob: '*bcf_filtered*'
+    secondaryFiles: ['.tbi?']

--- a/tools/kf_mskcc_vcf2maf.cwl
+++ b/tools/kf_mskcc_vcf2maf.cwl
@@ -20,7 +20,7 @@ arguments:
   - position: 1
     shellQuote: false
     valueFrom: >-
-      $(inputs.input_vcf.path) > input_file.vcf
+      > input_file.vcf
       && perl vcf2maf.pl
       --input-vcf input_file.vcf
       --output-maf $(inputs.output_basename).$(inputs.tool_name).vep.maf
@@ -28,7 +28,8 @@ arguments:
 inputs:
   reference: { type: 'File',  secondaryFiles: [.fai], doc: "Fasta genome assembly with index",
     inputBinding: {position: 2, prefix: "--ref-fasta"} }
-  input_vcf: { type: 'File', secondaryFiles: [.tbi], doc: "VEP annotated vcf file." }
+  input_vcf: { type: File, doc: "VEP annotated vcf file.", 
+    inputBinding: { position: 0 } }
   output_basename: string
   tumor_id: { type: string, inputBinding: {position: 3, prefix: "--tumor-id"} }
   normal_id: { type: string, inputBinding: {position: 4, prefix: "--normal-id"} }

--- a/workflows/kfdrc-germline-snv-annot-workflow.cwl
+++ b/workflows/kfdrc-germline-snv-annot-workflow.cwl
@@ -361,6 +361,6 @@ sbg:license: Apache License 2.0
 sbg:publisher: KFDRC
 
 "sbg:links":
-- id: 'https://github.com/kids-first/kids-first/kf-annotation-tools/releases/tag/v1.1.0'
+- id: 'https://github.com/kids-first/kids-first/kf-annotation-tools/releases/tag/v1.2.2'
   label: github-release
 

--- a/workflows/kfdrc-somatic-snv-annot-workflow.cwl
+++ b/workflows/kfdrc-somatic-snv-annot-workflow.cwl
@@ -352,5 +352,5 @@ $namespaces:
 "sbg:license": Apache License 2.0
 "sbg:publisher": KFDRC
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-annotation-tools/releases/tag/v1.2.1'
+- id: 'https://github.com/kids-first/kf-annotation-tools/releases/tag/v1.2.2'
   label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

A recent update in attempting to harden bcftools filer step with a pipefail caused the `include` expression to fail in somatic workflow. This was missed during testing since the somatic workflow was not pointing to this update. I have refactored the tool, removing the pipe of include-to-exclude functionality as it is never used and is more trouble that it's worth.

Fixes # BIXU-3657

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] [Standalone](https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/c7bd6336-c904-4d39-8e1b-1ea3ad46fb90/)
- [ ] [Within somatic wf](https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/49e4c70c-c38a-4ba4-b37d-94dd6cc7f6d3/)

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
