### PR TITLE
🐛  JG submodules now init

### DIFF
--- a/.github/workflows/release_submodule_updater.yml
+++ b/.github/workflows/release_submodule_updater.yml
@@ -45,6 +45,7 @@ jobs:
       with:
         repository: kids-first/kf-jointgenotyping-workflow
         path: joint-genotyping
+        submodules: true
     - id: get-germline-annot-version
       name: Get Germline Annotation Workflow Version
       run: |


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

The GHA was not initializing the annotation submodule in joint-genotyping. Added flag to enable.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested the commands locally but no way to know for sure if this will work until we try it.

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
